### PR TITLE
Cleaned up the switch statement

### DIFF
--- a/addons/Grenades/Incendiary.sqf
+++ b/addons/Grenades/Incendiary.sqf
@@ -16,12 +16,12 @@ switch (true) do										// Check if condition is met
 		  sleep 0.5;									// 0.5s Timer damage is assigned "seconds"
 		};
   
-    case(_damageRadius < 5 && _damageRadius > 2.5):		// 2.5 - 5m
+    case(_damageRadius < 5):		// 2.5 - 5m
 		{player setDamage (damage player + 0.10);     	// 10 damage per tick
 		 sleep 1;										// 1s Timer damage is assigned "seconds"
 		};
 		
-    case(_damageRadius < 10 && _damageRadius > 5):		// 5- 10m
+    case(_damageRadius < 10):		// 5- 10m
 		 {player setDamage (damage player + 0.05);     	// 5 damage per tick
 		  sleep 2;									    // 2s Timer damage is assigned "seconds"
 		 };


### PR DESCRIPTION
Hey Mokey,

On the gasDamage variable you can actually do with out the second condition that is being 'anded' together with the other conditions on the last two cases of the first switch for a TL;DR skip to the second paragraph.

I will explain below: the first case will be ran for values between negative infinity and 2.49 and the second case will be ran for values between 2.51 - 4.9 and the last case will run for values between 5.1 and 9.9 (Please note it could be 9.999999 and similar situation for other decimal places just enough to put it over/under the thresh hold)

Now my solution does the same thing. We don't need those second conditions on the last two cases of the switch because by the time we hit the second case we already know _damgeRadius is greater then 2.5 at that point or we would have ran the code for the first case instead. Same situation on the last case, we know _damageRadius is less than 10 and greater than 5 because if it was less then 5 it would have entered the second case of the switch instead.

I am not doing this to nit pick but rather to explain that I understand programming fundamentals and would love to work on this with you.

If you think I am wrong, no problem! Let's talk about it and work towards a solution together.

Please email me at jonathan.spengeman@gmail.com
